### PR TITLE
Fix Mac AppStore problems and prefs opening refactoring.

### DIFF
--- a/Mute Me Now/AppDelegate.m
+++ b/Mute Me Now/AppDelegate.m
@@ -7,6 +7,7 @@
 #import <MASShortcut/Shortcut.h>
 #import <CoreAudio/CoreAudio.h>
 #import <AudioToolbox/AudioServices.h>
+#import "ViewController.h"
 
 static const NSTouchBarItemIdentifier muteIdentifier = @"pp.mute";
 static NSString *const MASCustomShortcutKey = @"customShortcut";
@@ -128,8 +129,6 @@ AudioObjectPropertyListenerBlock onAudioDeviceMuteChange = NULL;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
-    [[[[NSApplication sharedApplication] windows] lastObject] close];
-
     DFRSystemModalShowsCloseBoxWhenFrontMost(YES);
 
     NSCustomTouchBarItem *mute = [[NSCustomTouchBarItem alloc] initWithIdentifier:muteIdentifier];
@@ -446,8 +445,10 @@ AudioObjectPropertyListenerBlock onAudioDeviceMuteChange = NULL;
 }
 
 - (void) openPrefsWindow {
-    // todo I saw a bug when pref window doesn't open (after night)
-    [[[[NSApplication sharedApplication] windows] lastObject] makeKeyAndOrderFront:nil];
+    NSStoryboard *mainStoryboard = [NSStoryboard storyboardWithName:@"Main" bundle:nil];
+    NSWindowController *prefsWindowController = [mainStoryboard instantiateControllerWithIdentifier:@"prefsWindowController"];
+    
+    [prefsWindowController showWindow:self];
     [[NSApplication sharedApplication] activateIgnoringOtherApps:true];
 }
 

--- a/Mute Me Now/Base.lproj/Main.storyboard
+++ b/Mute Me Now/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
@@ -692,7 +692,7 @@
         <!--Window Controller-->
         <scene sceneID="R2V-B0-nI4">
             <objects>
-                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                <windowController storyboardIdentifier="prefsWindowController" id="B8D-0N-5wS" sceneMemberID="viewController">
                     <window key="window" title="Mute me" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/Mute Me Now/Info.plist
+++ b/Mute Me Now/Info.plist
@@ -32,5 +32,7 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
 </dict>
 </plist>

--- a/Mute Me Now/Mute Me Now Launcher/Mute Me Now Launcher.xcodeproj/project.pbxproj
+++ b/Mute Me Now/Mute Me Now Launcher/Mute Me Now Launcher.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		11B86E811EDEAC980069D254 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		11B86E841EDEAC980069D254 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		11B86E861EDEAC980069D254 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C6B6195B216B3D4F00F06C6B /* Mute Me Now Launcher.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Mute Me Now Launcher.entitlements"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +57,7 @@
 		11B86E771EDEAC970069D254 /* Mute Me Now Launcher */ = {
 			isa = PBXGroup;
 			children = (
+				C6B6195B216B3D4F00F06C6B /* Mute Me Now Launcher.entitlements */,
 				11B86E781EDEAC970069D254 /* AppDelegate.h */,
 				11B86E791EDEAC970069D254 /* AppDelegate.m */,
 				11B86E7E1EDEAC970069D254 /* ViewController.h */,
@@ -265,7 +267,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_ENTITLEMENTS = "Mute Me Now Launcher/Mute Me Now Launcher.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 4TVB38S7R4;
@@ -282,7 +284,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_ENTITLEMENTS = "Mute Me Now Launcher/Mute Me Now Launcher.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 4TVB38S7R4;

--- a/Mute Me Now/Mute Me Now Launcher/Mute Me Now Launcher/Mute Me Now Launcher.entitlements
+++ b/Mute Me Now/Mute Me Now Launcher/Mute Me Now Launcher/Mute Me Now Launcher.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/Mute Me Now/ViewController.m
+++ b/Mute Me Now/ViewController.m
@@ -15,13 +15,11 @@ static void *MASObservingContext = &MASObservingContext;
     [super viewDidLoad];
     
     if ([[NSUserDefaults standardUserDefaults] objectForKey:@"auto_login"] == nil) {
-    
         // the opposite is used later
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"auto_login"];
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
-
-        
+    
     BOOL state = [[NSUserDefaults standardUserDefaults] boolForKey:@"auto_login"];
     [self.autoLoginState setState: !state];
     
@@ -33,19 +31,12 @@ static void *MASObservingContext = &MASObservingContext;
     
     BOOL useAlternateStatusBarIcons = [[NSUserDefaults standardUserDefaults] boolForKey:@"status_bar_alternate_icons"];
     [self.useAlternateStatusBarIcons setState: useAlternateStatusBarIcons];
-
-
-    // enable to nil out preferences
-    //[[NSUserDefaults standardUserDefaults] setObject:nil forKey:@"hide_status_bar"];
-    //[[NSUserDefaults standardUserDefaults] setObject:nil forKey:@"auto_login"];
-    //[[NSUserDefaults standardUserDefaults] synchronize];
     
     // Make a global context reference
     void *kGlobalShortcutContext = &kGlobalShortcutContext;
     
     // this sets the existing shortcut and allows it to save
     [self.masShortCutView setAssociatedUserDefaultsKey:MASCustomShortcutKey];
-
     
     // Implement when loading view
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -53,6 +44,7 @@ static void *MASObservingContext = &MASObservingContext;
                   options:NSKeyValueObservingOptionInitial
                   context:MASObservingContext];
 
+    // set version from plist to label
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     NSString *versionFieldValue = [NSString stringWithFormat:@"Version %@", version];
     [self.versionTextFieldCell setStringValue:versionFieldValue];
@@ -60,7 +52,6 @@ static void *MASObservingContext = &MASObservingContext;
 
 - (void) observeValueForKeyPath: (NSString*) keyPath ofObject: (id) object change: (NSDictionary*) change context: (void*) context
 {
-
     if (context != MASObservingContext) {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
@@ -83,15 +74,7 @@ static void *MASObservingContext = &MASObservingContext;
 
 -(void)viewDidAppear {
     [super viewDidAppear];
-    [[self.view window] setTitle:@"Mute me"];
-    [[self.view window] center];    
-}
-
-
-- (void)setRepresentedObject:(id)representedObject {
-    [super setRepresentedObject:representedObject];
-
-    [[[[NSApplication sharedApplication] windows] lastObject] setTitle:@"Mute Me"];
+    [[self.view window] center];
 }
 
 - (IBAction)quitPressed:(id)sender {


### PR DESCRIPTION
1) Fix Mac AppStore validation problems (application type -> Productivity; launcher to sandbox)
2) Opening the prefs window more properly (don't use windows.lastObject anymore)
3) Remove a pointer to initial controller in the storyboard